### PR TITLE
fix: incorrect dotenv pacakge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project demonstrates how to transfer videos from a Vimeo account to an Amaz
 - A bucket in Amazon S3
 ## Step-by-Step
 
-1. Install the necessary libraries using [pip](https://pypi.org/project/pip/): ```pip install boto3 requests dotenv vimeo``` 
+1. Install the necessary libraries using [pip](https://pypi.org/project/pip/): ```pip install boto3 requests python-dotenv vimeo``` 
 2. In the same directory as the python script, create a file called ```.env```, with the following format, and fill in the necessary fields:
  ``` 
  AWS_ACCESS_KEY = ''


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the readme it says to use `pip install dotenv` for python3 this should be `pip install python-dotenv`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
